### PR TITLE
Исправление аутентификации в 1C Designer (issue #8)

### DIFF
--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/DesignerBuildAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/DesignerBuildAction.kt
@@ -5,6 +5,7 @@ import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
 import io.github.alkoleft.mcp.configuration.properties.SourceSet
 import io.github.alkoleft.mcp.core.modules.ShellCommandResult
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
+import io.github.alkoleft.mcp.infrastructure.utility.ifNoBlank
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -35,6 +36,8 @@ class DesignerBuildAction(
         dsl.configurator {
             // Подключаемся к информационной базе
             connect(properties.connection.connectionString)
+            properties.connection.user?.ifNoBlank { user(it) }
+            properties.connection.password?.ifNoBlank { password(it) }
 
             // Отключаем диалоги и сообщения для автоматической работы
             disableStartupDialogs()


### PR DESCRIPTION
- Добавлены вызовы user() и password() в DesignerBuildAction.executeBuildDsl() для передачи учетных данных из ConnectionProperties
- Импорт расширения ifNoBlank для безопасной обработки строк user/password
- Обеспечивает работу аутентификации на базах с пользователями, предотвращая ошибку 'Пользователь ИБ не идентифицирован'

Close #8 