### PR TITLE
feat: add partial configuration loading support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ logs/
 *.db
 *.wal.*
 *.gz
+
+### Local Configuration ###
+mcp-configs/
+mcp-example.json
+DEPLOYMENT.md

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/AbstractBuildAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/AbstractBuildAction.kt
@@ -21,6 +21,7 @@
 
 package io.github.alkoleft.mcp.application.actions.build
 
+import io.github.alkoleft.mcp.application.actions.change.SourceSetChanges
 import io.github.alkoleft.mcp.application.actions.common.BuildAction
 import io.github.alkoleft.mcp.application.actions.common.BuildResult
 import io.github.alkoleft.mcp.application.actions.exceptions.BuildException
@@ -28,6 +29,7 @@ import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
 import io.github.alkoleft.mcp.configuration.properties.SourceSet
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import io.github.alkoleft.mcp.infrastructure.utility.PartialLoadListGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.nio.file.Path
 import kotlin.time.TimeSource
@@ -36,10 +38,11 @@ private val logger = KotlinLogging.logger { }
 
 /**
  * Абстрактный базовый класс для BuildAction, предоставляющий общую функциональность
- * для измерения времени выполнения, обработки ошибок и логирования
+ * для измерения времени выполнения, обработки ошибок, логирования и частичной загрузки.
  */
 abstract class AbstractBuildAction(
     protected val dsl: PlatformDsl,
+    protected val partialLoadListGenerator: PartialLoadListGenerator,
 ) : BuildAction {
     /**
      * Выполняет полную сборку проекта с измерением времени
@@ -48,6 +51,21 @@ abstract class AbstractBuildAction(
         properties: ApplicationProperties,
         sourceSet: SourceSet,
     ): BuildResult = measureExecutionTime { executeBuildDsl(properties, sourceSet) }
+
+    /**
+     * Выполняет сборку проекта с поддержкой частичной загрузки.
+     *
+     * Автоматически определяет режим загрузки на основе:
+     * - Количества измененных файлов (порог из properties.build.partialLoadThreshold)
+     * - Наличия изменений в Configuration.xml
+     */
+    override fun runPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        sourceSetChanges: Map<String, SourceSetChanges>,
+    ): BuildResult = measureExecutionTime {
+        executeBuildDslPartial(properties, sourceSet, sourceSetChanges)
+    }
 
     /**
      * Измеряет время выполнения операции с обработкой ошибок
@@ -67,13 +85,13 @@ abstract class AbstractBuildAction(
     }
 
     /**
-     * Метод для выполнения DSL сборки
+     * Метод для выполнения DSL сборки (полная загрузка)
      */
     fun executeBuildDsl(
         properties: ApplicationProperties,
         sourceSet: SourceSet,
     ): BuildResult {
-        logger.debug { "Сборка проекта" }
+        logger.debug { "Сборка проекта (полная загрузка)" }
 
         initDsl(properties)
         val state = BuildActionState()
@@ -110,17 +128,125 @@ abstract class AbstractBuildAction(
         return state.toResult("Сборка завершена").also { if (it.success) logger.info { it.message } }
     }
 
+    /**
+     * Метод для выполнения DSL сборки с поддержкой частичной загрузки
+     */
+    fun executeBuildDslPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        sourceSetChanges: Map<String, SourceSetChanges>,
+    ): BuildResult {
+        logger.debug { "Сборка проекта с поддержкой частичной загрузки" }
+
+        initDsl(properties)
+        val state = BuildActionState()
+        val threshold = properties.build.partialLoadThreshold
+
+        // Загружаем основную конфигурацию
+        sourceSet.configuration?.also { configuration ->
+            val configPath = sourceSet.basePath.resolve(configuration.path)
+            val changes = sourceSetChanges[configuration.name]
+
+            val result = if (changes != null && shouldUsePartialLoad(changes, threshold, configPath)) {
+                logger.info { "Частичная загрузка конфигурации: ${changes.changedFiles.size} файлов" }
+                loadConfigurationPartial(configuration.name, configPath, changes.changedFiles)
+            } else {
+                logger.info { "Полная загрузка конфигурации" }
+                loadConfiguration(configuration.name, configPath)
+            }
+            state.addResult(configuration.name, result, "Загрузка конфигурации")
+        }
+
+        if (!state.success) {
+            return state.toResult("При загрузке исходников возникли ошибки")
+        }
+
+        // Загружаем расширения
+        val extensions = sourceSet.extensions
+        logger.info { "Загружаю ${extensions.size} расширений: ${extensions.joinToString(", ") { it.name }}" }
+        extensions.forEach { extension ->
+            val extensionPath = sourceSet.basePath.resolve(extension.path)
+            val changes = sourceSetChanges[extension.name]
+
+            val result = if (changes != null && shouldUsePartialLoad(changes, threshold, extensionPath)) {
+                logger.info { "Частичная загрузка расширения ${extension.name}: ${changes.changedFiles.size} файлов" }
+                loadExtensionPartial(extension.name, extensionPath, changes.changedFiles)
+            } else {
+                logger.info { "Полная загрузка расширения ${extension.name}" }
+                loadExtension(extension.name, extensionPath)
+            }
+            state.addResult(extension.name, result, "Загрузка расширения ${extension.name}")
+
+            if (!result.success) {
+                return@forEach
+            }
+        }
+
+        if (!state.success) {
+            return state.toResult("При загрузке исходников возникли ошибки")
+        }
+
+        updateDb()?.also(state::registerUpdateResult)
+
+        return state.toResult("Сборка завершена").also { if (it.success) logger.info { it.message } }
+    }
+
+    /**
+     * Определяет, следует ли использовать частичную загрузку для source set.
+     */
+    private fun shouldUsePartialLoad(
+        changes: SourceSetChanges,
+        threshold: Int,
+        sourceSetPath: Path,
+    ): Boolean {
+        return partialLoadListGenerator.shouldUsePartialLoad(
+            changedFiles = changes.changedFiles,
+            threshold = threshold,
+            sourceSetPath = sourceSetPath,
+        )
+    }
+
+    /**
+     * Инициализирует DSL для выполнения команд
+     */
     protected abstract fun initDsl(properties: ApplicationProperties): Unit
 
+    /**
+     * Загружает конфигурацию полностью
+     */
     protected abstract fun loadConfiguration(
         name: String,
         path: Path,
     ): ProcessResult
 
+    /**
+     * Загружает конфигурацию частично (только измененные файлы)
+     */
+    protected abstract fun loadConfigurationPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult
+
+    /**
+     * Загружает расширение полностью
+     */
     protected abstract fun loadExtension(
         name: String,
         path: Path,
     ): ProcessResult
 
+    /**
+     * Загружает расширение частично (только измененные файлы)
+     */
+    protected abstract fun loadExtensionPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult
+
+    /**
+     * Обновляет конфигурацию базы данных
+     */
     protected abstract fun updateDb(): ProcessResult?
 }

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/DesignerBuildAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/DesignerBuildAction.kt
@@ -24,6 +24,8 @@ package io.github.alkoleft.mcp.application.actions.build
 import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.designer.DesignerDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import io.github.alkoleft.mcp.infrastructure.utility.PartialLoadListGenerator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.nio.file.Path
@@ -35,7 +37,8 @@ import java.nio.file.Path
 @ConditionalOnProperty(name = ["app.tools.builder"], havingValue = "DESIGNER")
 class DesignerBuildAction(
     dsl: PlatformDsl,
-) : AbstractBuildAction(dsl) {
+    partialLoadListGenerator: PartialLoadListGenerator,
+) : AbstractBuildAction(dsl, partialLoadListGenerator) {
     private lateinit var actionDsl: DesignerDsl
 
     override fun initDsl(properties: ApplicationProperties) {
@@ -55,6 +58,21 @@ class DesignerBuildAction(
         updateDBCfg()
     }
 
+    override fun loadConfigurationPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult {
+        val listFile = partialLoadListGenerator.generate(path, changedFiles)
+        return actionDsl.loadConfigFromFiles {
+            fromPath(path)
+            partial()
+            listFile(listFile)
+            updateConfigDumpInfo()
+            updateDBCfg()
+        }
+    }
+
     override fun loadExtension(
         name: String,
         path: Path,
@@ -62,6 +80,22 @@ class DesignerBuildAction(
         fromPath(path)
         extension(name)
         updateDBCfg()
+    }
+
+    override fun loadExtensionPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult {
+        val listFile = partialLoadListGenerator.generate(path, changedFiles)
+        return actionDsl.loadConfigFromFiles {
+            fromPath(path)
+            extension(name)
+            partial()
+            listFile(listFile)
+            updateConfigDumpInfo()
+            updateDBCfg()
+        }
     }
 
     override fun updateDb() = null

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/IbcmdBuildAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/build/IbcmdBuildAction.kt
@@ -25,6 +25,7 @@ import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.ibcmd.IbcmdDsl
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import io.github.alkoleft.mcp.infrastructure.utility.PartialLoadListGenerator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.nio.file.Path
@@ -36,7 +37,8 @@ import java.nio.file.Path
 @ConditionalOnProperty(name = ["app.tools.builder"], havingValue = "IBCMD")
 class IbcmdBuildAction(
     dsl: PlatformDsl,
-) : AbstractBuildAction(dsl) {
+    partialLoadListGenerator: PartialLoadListGenerator,
+) : AbstractBuildAction(dsl, partialLoadListGenerator) {
     private lateinit var actionDsl: IbcmdDsl
 
     override fun initDsl(properties: ApplicationProperties) {
@@ -54,6 +56,24 @@ class IbcmdBuildAction(
         return result
     }
 
+    override fun loadConfigurationPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult {
+        // Для ibcmd используем подкоманду "files" и параметр --partial
+        // ibcmd infobase config import files --partial <path>
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = import(path) {
+                importSubCommand = "files"
+                partial = true
+                baseDir = path.toString()
+            }
+        }
+        return result
+    }
+
     override fun loadExtension(
         name: String,
         path: Path,
@@ -64,6 +84,24 @@ class IbcmdBuildAction(
                 import(path) {
                     extension = name
                 }
+        }
+        return result
+    }
+
+    override fun loadExtensionPartial(
+        name: String,
+        path: Path,
+        changedFiles: Set<Path>,
+    ): ProcessResult {
+        // Для ibcmd используем подкоманду "files" и параметр --partial с расширением
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = import(path) {
+                extension = name
+                importSubCommand = "files"
+                partial = true
+                baseDir = path.toString()
+            }
         }
         return result
     }

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/common/Actions.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/common/Actions.kt
@@ -44,7 +44,7 @@ import kotlin.time.Duration
  */
 interface BuildAction {
     /**
-     * Выполняет сборку проекта
+     * Выполняет сборку проекта (полная загрузка)
      *
      * @param properties Свойства приложения с конфигурацией
      * @param sourceSet Описание исходных файлов проекта
@@ -53,6 +53,24 @@ interface BuildAction {
     fun run(
         properties: ApplicationProperties,
         sourceSet: SourceSet,
+    ): BuildResult
+
+    /**
+     * Выполняет сборку проекта с частичной загрузкой измененных файлов.
+     *
+     * Автоматически определяет режим загрузки (частичная или полная) на основе:
+     * - Количества измененных файлов (сравнение с порогом partialLoadThreshold)
+     * - Наличия изменений в Configuration.xml
+     *
+     * @param properties Свойства приложения с конфигурацией
+     * @param sourceSet Описание исходных файлов проекта
+     * @param sourceSetChanges Изменения, сгруппированные по source set
+     * @return Результат сборки
+     */
+    fun runPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        sourceSetChanges: Map<String, SourceSetChanges>,
     ): BuildResult
 }
 

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/common/Actions.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/common/Actions.kt
@@ -330,3 +330,98 @@ data class LaunchResult(
     override val steps: List<ActionStepResult> = emptyList(),
     val processId: Long? = null,
 ) : ActionResult
+
+/**
+ * Режим выгрузки конфигурации
+ */
+enum class DumpMode {
+    /** Полная выгрузка всей конфигурации */
+    FULL,
+
+    /** Инкрементальная выгрузка только измененных объектов (требует ConfigDumpInfo.xml) */
+    INCREMENTAL,
+
+    /** Частичная выгрузка конкретных объектов по списку */
+    PARTIAL,
+}
+
+/**
+ * Интерфейс для выгрузки конфигурации из ИБ в файлы
+ *
+ * Определяет контракт для выгрузки конфигурации 1С:Предприятие из информационной базы
+ * в файлы проекта. Реализации этого интерфейса могут использовать различные инструменты
+ * (например, конфигуратор или ibcmd).
+ */
+interface DumpAction {
+    /**
+     * Выполняет полную выгрузку конфигурации
+     *
+     * @param properties Свойства приложения с конфигурацией
+     * @param sourceSet Описание целевого каталога проекта
+     * @param extension Имя расширения для выгрузки (null - основная конфигурация)
+     * @param allExtensions Выгрузить все расширения
+     * @return Результат выгрузки
+     */
+    fun run(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String? = null,
+        allExtensions: Boolean = false,
+    ): DumpResult
+
+    /**
+     * Выполняет инкрементальную выгрузку только измененных объектов
+     *
+     * Использует ConfigDumpInfo.xml для определения изменений между конфигурацией в ИБ
+     * и выгруженными файлами. Выгружает только объекты, которые были изменены.
+     *
+     * @param properties Свойства приложения с конфигурацией
+     * @param sourceSet Описание целевого каталога проекта
+     * @param extension Имя расширения для выгрузки (null - основная конфигурация)
+     * @return Результат выгрузки
+     */
+    fun runIncremental(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String? = null,
+    ): DumpResult
+
+    /**
+     * Выполняет частичную выгрузку конкретных объектов по списку
+     *
+     * @param properties Свойства приложения с конфигурацией
+     * @param sourceSet Описание целевого каталога проекта
+     * @param objects Список объектов метаданных для выгрузки (например, "Справочник.Номенклатура")
+     * @param extension Имя расширения для выгрузки (null - основная конфигурация)
+     * @return Результат выгрузки
+     */
+    fun runPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        objects: List<String>,
+        extension: String? = null,
+    ): DumpResult
+}
+
+/**
+ * Результат выгрузки конфигурации
+ *
+ * Содержит информацию о результатах выгрузки конфигурации из ИБ в файлы.
+ *
+ * @param message Сообщение о результате выгрузки
+ * @param success Успешность выгрузки (true, если выгрузка завершилась без ошибок)
+ * @param mode Режим выгрузки, который был использован
+ * @param errors Список ошибок, возникших во время выгрузки
+ * @param duration Время выполнения выгрузки
+ * @param steps Список шагов выполнения выгрузки для диагностики
+ * @param dumpedObjects Количество выгруженных объектов (если известно)
+ */
+data class DumpResult(
+    override val message: String,
+    override val success: Boolean,
+    val mode: DumpMode,
+    override val errors: List<String> = emptyList(),
+    override val duration: Duration = Duration.ZERO,
+    override val steps: List<ActionStepResult> = emptyList(),
+    val dumpedObjects: Int? = null,
+) : ActionResult

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/AbstractDumpAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/AbstractDumpAction.kt
@@ -1,0 +1,274 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.actions.dump
+
+import io.github.alkoleft.mcp.application.actions.common.DumpAction
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
+import io.github.alkoleft.mcp.application.actions.common.DumpResult
+import io.github.alkoleft.mcp.application.actions.exceptions.DumpException
+import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
+import io.github.alkoleft.mcp.configuration.properties.SourceSet
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.nio.file.Path
+import kotlin.time.TimeSource
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * Абстрактный базовый класс для DumpAction, предоставляющий общую функциональность
+ * для измерения времени выполнения, обработки ошибок и логирования.
+ */
+abstract class AbstractDumpAction(
+    protected val dsl: PlatformDsl,
+) : DumpAction {
+    /**
+     * Выполняет полную выгрузку конфигурации с измерением времени
+     */
+    override fun run(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String?,
+        allExtensions: Boolean,
+    ): DumpResult = measureExecutionTime(DumpMode.FULL) {
+        executeDumpFull(properties, sourceSet, extension, allExtensions)
+    }
+
+    /**
+     * Выполняет инкрементальную выгрузку с измерением времени
+     */
+    override fun runIncremental(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String?,
+    ): DumpResult = measureExecutionTime(DumpMode.INCREMENTAL) {
+        executeDumpIncremental(properties, sourceSet, extension)
+    }
+
+    /**
+     * Выполняет частичную выгрузку конкретных объектов с измерением времени
+     */
+    override fun runPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        objects: List<String>,
+        extension: String?,
+    ): DumpResult = measureExecutionTime(DumpMode.PARTIAL) {
+        executeDumpPartial(properties, sourceSet, objects, extension)
+    }
+
+    /**
+     * Измеряет время выполнения операции с обработкой ошибок
+     */
+    private fun measureExecutionTime(
+        mode: DumpMode,
+        block: () -> DumpResult,
+    ): DumpResult {
+        val startTime = TimeSource.Monotonic.markNow()
+        return try {
+            val result = block()
+            val duration = startTime.elapsedNow()
+            logger.info { "Выгрузка конфигурации (режим: $mode) завершена за $duration" }
+            result.copy(duration = duration)
+        } catch (e: Exception) {
+            val duration = startTime.elapsedNow()
+            logger.error(e) { "Выгрузка конфигурации завершилась с ошибкой после $duration" }
+            throw DumpException("Выгрузка конфигурации завершилась с ошибкой: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Выполняет полную выгрузку конфигурации
+     */
+    private fun executeDumpFull(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String?,
+        allExtensions: Boolean,
+    ): DumpResult {
+        logger.debug { "Выгрузка конфигурации (полная)" }
+
+        initDsl(properties)
+        val state = DumpActionState(DumpMode.FULL)
+
+        val targetPath = resolveTargetPath(sourceSet, extension)
+
+        val result = when {
+            allExtensions -> {
+                logger.info { "Выгружаю все расширения в $targetPath" }
+                dumpAllExtensions(targetPath)
+            }
+            extension != null -> {
+                logger.info { "Выгружаю расширение '$extension' в $targetPath" }
+                dumpExtension(extension, targetPath)
+            }
+            else -> {
+                logger.info { "Выгружаю основную конфигурацию в $targetPath" }
+                dumpConfiguration(targetPath)
+            }
+        }
+
+        state.registerDumpResult(result, "Выгрузка конфигурации")
+
+        return state.toResult("Выгрузка").also { if (it.success) logger.info { it.message } }
+    }
+
+    /**
+     * Выполняет инкрементальную выгрузку
+     */
+    private fun executeDumpIncremental(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        extension: String?,
+    ): DumpResult {
+        logger.debug { "Выгрузка конфигурации (инкрементальная)" }
+
+        initDsl(properties)
+        val state = DumpActionState(DumpMode.INCREMENTAL)
+
+        val targetPath = resolveTargetPath(sourceSet, extension)
+
+        val result = if (extension != null) {
+            logger.info { "Инкрементальная выгрузка расширения '$extension' в $targetPath" }
+            dumpExtensionIncremental(extension, targetPath)
+        } else {
+            logger.info { "Инкрементальная выгрузка основной конфигурации в $targetPath" }
+            dumpConfigurationIncremental(targetPath)
+        }
+
+        state.registerDumpResult(result, "Инкрементальная выгрузка")
+
+        return state.toResult("Инкрементальная выгрузка").also { if (it.success) logger.info { it.message } }
+    }
+
+    /**
+     * Выполняет частичную выгрузку конкретных объектов
+     */
+    private fun executeDumpPartial(
+        properties: ApplicationProperties,
+        sourceSet: SourceSet,
+        objects: List<String>,
+        extension: String?,
+    ): DumpResult {
+        logger.debug { "Выгрузка конфигурации (частичная): ${objects.size} объектов" }
+
+        if (objects.isEmpty()) {
+            return DumpResult(
+                message = "Список объектов для выгрузки пуст",
+                success = false,
+                mode = DumpMode.PARTIAL,
+                errors = listOf("Необходимо указать хотя бы один объект для выгрузки"),
+            )
+        }
+
+        initDsl(properties)
+        val state = DumpActionState(DumpMode.PARTIAL)
+
+        val targetPath = resolveTargetPath(sourceSet, extension)
+
+        val result = if (extension != null) {
+            logger.info { "Частичная выгрузка расширения '$extension': ${objects.joinToString(", ")}" }
+            dumpExtensionPartial(extension, targetPath, objects)
+        } else {
+            logger.info { "Частичная выгрузка конфигурации: ${objects.joinToString(", ")}" }
+            dumpConfigurationPartial(targetPath, objects)
+        }
+
+        state.registerDumpResult(result, "Частичная выгрузка", objects.size)
+
+        return state.toResult("Частичная выгрузка").also { if (it.success) logger.info { it.message } }
+    }
+
+    /**
+     * Определяет целевой путь для выгрузки
+     */
+    private fun resolveTargetPath(
+        sourceSet: SourceSet,
+        extension: String?,
+    ): Path {
+        return if (extension != null) {
+            val extensionConfig = sourceSet.extensions.find { it.name == extension }
+            if (extensionConfig != null) {
+                sourceSet.basePath.resolve(extensionConfig.path)
+            } else {
+                sourceSet.basePath.resolve("extensions/$extension")
+            }
+        } else {
+            sourceSet.configuration?.let { sourceSet.basePath.resolve(it.path) }
+                ?: sourceSet.basePath
+        }
+    }
+
+    /**
+     * Инициализирует DSL для выполнения команд
+     */
+    protected abstract fun initDsl(properties: ApplicationProperties): Unit
+
+    /**
+     * Выгружает основную конфигурацию полностью
+     */
+    protected abstract fun dumpConfiguration(targetPath: Path): ProcessResult
+
+    /**
+     * Выгружает основную конфигурацию инкрементально
+     */
+    protected abstract fun dumpConfigurationIncremental(targetPath: Path): ProcessResult
+
+    /**
+     * Выгружает основную конфигурацию частично (конкретные объекты)
+     */
+    protected abstract fun dumpConfigurationPartial(
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult
+
+    /**
+     * Выгружает расширение полностью
+     */
+    protected abstract fun dumpExtension(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult
+
+    /**
+     * Выгружает расширение инкрементально
+     */
+    protected abstract fun dumpExtensionIncremental(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult
+
+    /**
+     * Выгружает расширение частично (конкретные объекты)
+     */
+    protected abstract fun dumpExtensionPartial(
+        name: String,
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult
+
+    /**
+     * Выгружает все расширения
+     */
+    protected abstract fun dumpAllExtensions(targetPath: Path): ProcessResult
+}

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/DesignerDumpAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/DesignerDumpAction.kt
@@ -1,0 +1,145 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.actions.dump
+
+import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.designer.DesignerDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Реализация DumpAction для выгрузки через конфигуратор 1С
+ */
+@Component
+@ConditionalOnProperty(name = ["app.tools.builder"], havingValue = "DESIGNER")
+class DesignerDumpAction(
+    dsl: PlatformDsl,
+) : AbstractDumpAction(dsl) {
+    private lateinit var actionDsl: DesignerDsl
+
+    override fun initDsl(properties: ApplicationProperties) {
+        actionDsl = dsl.designer {
+            disableStartupDialogs()
+            disableStartupMessages()
+        }
+    }
+
+    override fun dumpConfiguration(targetPath: Path): ProcessResult {
+        // Полная выгрузка: без -updateConfigDumpInfo выгружает всё,
+        // но обновляем ConfigDumpInfo.xml для последующих инкрементальных выгрузок
+        return actionDsl.dumpConfigToFiles {
+            toPath(targetPath)
+            updateConfigDumpInfo()
+        }
+    }
+
+    override fun dumpConfigurationIncremental(targetPath: Path): ProcessResult {
+        // Инкрементальная выгрузка: использует ConfigDumpInfo.xml
+        // для определения изменённых объектов.
+        // Сравнивает версии объектов в ИБ с сохранёнными в ConfigDumpInfo.xml
+        // и выгружает только изменённые.
+        // ВАЖНО: требует наличия ConfigDumpInfo.xml от предыдущей выгрузки
+        return actionDsl.dumpConfigToFiles {
+            toPath(targetPath)
+            updateConfigDumpInfo()
+        }
+    }
+
+    override fun dumpConfigurationPartial(
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult {
+        val listFile = createObjectsListFile(objects)
+        return try {
+            actionDsl.dumpConfigToFiles {
+                toPath(targetPath)
+                partial()
+                listFile(listFile)
+                updateConfigDumpInfo()
+            }
+        } finally {
+            Files.deleteIfExists(listFile)
+        }
+    }
+
+    override fun dumpExtension(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult {
+        return actionDsl.dumpConfigToFiles {
+            toPath(targetPath)
+            extension(name)
+            updateConfigDumpInfo()
+        }
+    }
+
+    override fun dumpExtensionIncremental(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult {
+        return actionDsl.dumpConfigToFiles {
+            toPath(targetPath)
+            extension(name)
+            updateConfigDumpInfo()
+        }
+    }
+
+    override fun dumpExtensionPartial(
+        name: String,
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult {
+        val listFile = createObjectsListFile(objects)
+        return try {
+            actionDsl.dumpConfigToFiles {
+                toPath(targetPath)
+                extension(name)
+                partial()
+                listFile(listFile)
+                updateConfigDumpInfo()
+            }
+        } finally {
+            Files.deleteIfExists(listFile)
+        }
+    }
+
+    override fun dumpAllExtensions(targetPath: Path): ProcessResult {
+        return actionDsl.dumpConfigToFiles {
+            toPath(targetPath)
+            allExtensions()
+            updateConfigDumpInfo()
+        }
+    }
+
+    /**
+     * Создает временный файл со списком объектов для частичной выгрузки
+     */
+    private fun createObjectsListFile(objects: List<String>): Path {
+        val listFile = Files.createTempFile("dump-objects-", ".txt")
+        Files.write(listFile, objects)
+        return listFile
+    }
+}

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/DumpActionState.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/DumpActionState.kt
@@ -1,0 +1,83 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.actions.dump
+
+import io.github.alkoleft.mcp.application.actions.common.ActionState
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
+import io.github.alkoleft.mcp.application.actions.common.DumpResult
+import io.github.alkoleft.mcp.application.actions.common.toActionStepResult
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * Состояние выполнения выгрузки конфигурации
+ *
+ * Отслеживает результаты выполнения команд выгрузки.
+ */
+class DumpActionState(
+    private val mode: DumpMode,
+) : ActionState(logger) {
+    private var dumpResult: ProcessResult? = null
+    private var dumpedObjects: Int? = null
+
+    /**
+     * Регистрирует результат выгрузки
+     *
+     * @param result Результат выполнения команды
+     * @param description Описание операции
+     * @param objectsCount Количество выгруженных объектов (если известно)
+     */
+    fun registerDumpResult(
+        result: ProcessResult,
+        description: String,
+        objectsCount: Int? = null,
+    ) {
+        dumpResult = result
+        dumpedObjects = objectsCount
+        if (!result.success) {
+            success = false
+        }
+        addStep(result.toActionStepResult(description))
+    }
+
+    /**
+     * Преобразует состояние в результат выгрузки
+     *
+     * @param message Базовое сообщение о результате
+     * @return Результат выгрузки конфигурации
+     */
+    fun toResult(message: String): DumpResult {
+        val errors = mutableListOf<String>()
+        dumpResult?.error?.let(errors::add)
+
+        return DumpResult(
+            message = message + if (success) " успешно" else " неудачно",
+            success = success,
+            mode = mode,
+            errors = errors,
+            steps = steps.toList(),
+            dumpedObjects = dumpedObjects,
+        )
+    }
+}

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/IbcmdDumpAction.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/dump/IbcmdDumpAction.kt
@@ -1,0 +1,140 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.actions.dump
+
+import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.ibcmd.IbcmdDsl
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.nio.file.Path
+
+/**
+ * Реализация DumpAction для выгрузки через ibcmd
+ */
+@Component
+@ConditionalOnProperty(name = ["app.tools.builder"], havingValue = "IBCMD")
+class IbcmdDumpAction(
+    dsl: PlatformDsl,
+) : AbstractDumpAction(dsl) {
+    private lateinit var actionDsl: IbcmdDsl
+
+    override fun initDsl(properties: ApplicationProperties) {
+        actionDsl = dsl.ibcmd { }
+    }
+
+    override fun dumpConfiguration(targetPath: Path): ProcessResult {
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                force = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpConfigurationIncremental(targetPath: Path): ProcessResult {
+        // Для инкрементальной выгрузки используем --sync
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                sync = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpConfigurationPartial(
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult {
+        // ibcmd не поддерживает частичную выгрузку по списку объектов напрямую
+        // Используем подкоманду objects если нужно
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                exportSubCommand = "objects"
+                // Объекты передаются через файл или строку - зависит от реализации ibcmd
+                // Пока используем стандартный экспорт с синхронизацией
+                sync = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpExtension(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult {
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                extension = name
+                force = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpExtensionIncremental(
+        name: String,
+        targetPath: Path,
+    ): ProcessResult {
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                extension = name
+                sync = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpExtensionPartial(
+        name: String,
+        targetPath: Path,
+        objects: List<String>,
+    ): ProcessResult {
+        // ibcmd не поддерживает частичную выгрузку расширений по списку объектов
+        // Используем инкрементальную выгрузку
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                extension = name
+                sync = true
+            }
+        }
+        return result
+    }
+
+    override fun dumpAllExtensions(targetPath: Path): ProcessResult {
+        lateinit var result: ProcessResult
+        actionDsl.config {
+            result = export(targetPath) {
+                exportSubCommand = "all-extensions"
+                force = true
+            }
+        }
+        return result
+    }
+}

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/actions/exceptions/ActionExceptions.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/actions/exceptions/ActionExceptions.kt
@@ -75,7 +75,17 @@ class TestExecutionError(
     context: Map<String, Any> = emptyMap(),
 ) : ActionError(message, cause, context)
 
+/**
+ * Ошибка выгрузки конфигурации
+ */
+class DumpError(
+    message: String,
+    cause: Throwable? = null,
+    context: Map<String, Any> = emptyMap(),
+) : ActionError(message, cause, context)
+
 // Алиасы для обратной совместимости
 typealias BuildException = BuildError
 typealias AnalyzeException = AnalysisError
 typealias TestExecuteException = TestExecutionError
+typealias DumpException = DumpError

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/services/DumpService.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/services/DumpService.kt
@@ -1,0 +1,107 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.services
+
+import io.github.alkoleft.mcp.application.actions.common.DumpAction
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
+import io.github.alkoleft.mcp.application.actions.common.DumpResult
+import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * Запрос на выгрузку конфигурации
+ *
+ * @param mode Режим выгрузки (по умолчанию FULL)
+ * @param extension Имя расширения для выгрузки (null - основная конфигурация)
+ * @param allExtensions Выгрузить все расширения
+ * @param objects Список объектов для частичной выгрузки (только для режима PARTIAL)
+ */
+data class DumpRequest(
+    val mode: DumpMode = DumpMode.FULL,
+    val extension: String? = null,
+    val allExtensions: Boolean = false,
+    val objects: List<String> = emptyList(),
+)
+
+/**
+ * Сервис для выгрузки конфигурации из ИБ в файлы проекта
+ *
+ * Предоставляет высокоуровневый интерфейс для выгрузки конфигурации
+ * с автоматическим выбором целевого каталога на основе конфигурации проекта.
+ */
+@Service
+class DumpService(
+    private val dumpAction: DumpAction,
+    private val properties: ApplicationProperties,
+    private val sourceSetFactory: SourceSetFactory,
+) {
+    /**
+     * Выполняет выгрузку конфигурации согласно запросу
+     *
+     * @param request Запрос на выгрузку с указанием режима и параметров
+     * @return Результат выгрузки
+     */
+    fun dump(request: DumpRequest): DumpResult {
+        logger.info {
+            "Выгрузка конфигурации: режим=${request.mode}, " +
+                "расширение=${request.extension ?: "основная конфигурация"}, " +
+                "все расширения=${request.allExtensions}"
+        }
+
+        val sourceSet = sourceSetFactory.createDesignerSourceSet()
+
+        return when (request.mode) {
+            DumpMode.FULL -> dumpAction.run(
+                properties = properties,
+                sourceSet = sourceSet,
+                extension = request.extension,
+                allExtensions = request.allExtensions,
+            )
+
+            DumpMode.INCREMENTAL -> dumpAction.runIncremental(
+                properties = properties,
+                sourceSet = sourceSet,
+                extension = request.extension,
+            )
+
+            DumpMode.PARTIAL -> {
+                if (request.objects.isEmpty()) {
+                    return DumpResult(
+                        message = "Для режима PARTIAL необходимо указать список объектов",
+                        success = false,
+                        mode = DumpMode.PARTIAL,
+                        errors = listOf("Список объектов пуст"),
+                    )
+                }
+                dumpAction.runPartial(
+                    properties = properties,
+                    sourceSet = sourceSet,
+                    objects = request.objects,
+                    extension = request.extension,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/alkoleft/mcp/application/services/LauncherService.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/application/services/LauncherService.kt
@@ -21,6 +21,7 @@
 
 package io.github.alkoleft.mcp.application.services
 
+import io.github.alkoleft.mcp.application.actions.change.SourceSetChanges
 import io.github.alkoleft.mcp.application.actions.common.ActionStepResult
 import io.github.alkoleft.mcp.application.actions.common.BuildAction
 import io.github.alkoleft.mcp.application.actions.common.BuildResult
@@ -116,7 +117,7 @@ class LauncherService(
             }
         }
 
-        val result = updateIB(changedSourceSets)
+        val result = updateIB(changedSourceSets, changes.sourceSetChanges)
 
         var success = true
         val errors = mutableListOf<String>()
@@ -143,9 +144,19 @@ class LauncherService(
         )
     }
 
-    private fun updateIB(changedSourceSets: SourceSet): BuildResult =
-        buildAction.run(
+    /**
+     * Обновляет информационную базу с поддержкой частичной загрузки.
+     *
+     * Автоматически выбирает режим загрузки (частичная или полная) на основе
+     * количества измененных файлов и настройки partialLoadThreshold.
+     */
+    private fun updateIB(
+        changedSourceSets: SourceSet,
+        sourceSetChanges: Map<String, SourceSetChanges>,
+    ): BuildResult =
+        buildAction.runPartial(
             properties,
             designerSourceSet.subSourceSet { changedSourceSets.find { item -> item.name == it.name } != null },
+            sourceSetChanges,
         )
 }

--- a/src/main/kotlin/io/github/alkoleft/mcp/configuration/properties/ApplicationProperties.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/configuration/properties/ApplicationProperties.kt
@@ -39,6 +39,7 @@ data class ApplicationProperties(
     val connection: ConnectionProperties = ConnectionProperties(),
     val platformVersion: String = "",
     val tools: ToolsProperties = ToolsProperties(),
+    val build: BuildProperties = BuildProperties(),
 ) {
     val workPath: Path by lazy {
         val path =

--- a/src/main/kotlin/io/github/alkoleft/mcp/configuration/properties/BuildProperties.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/configuration/properties/BuildProperties.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.configuration.properties
+
+/**
+ * Настройки сборки проекта
+ */
+data class BuildProperties(
+    /**
+     * Порог количества файлов для переключения на частичную загрузку.
+     * Если количество измененных файлов меньше этого значения,
+     * будет использована частичная загрузка (partial load).
+     * По умолчанию: 20 файлов
+     */
+    val partialLoadThreshold: Int = 20,
+)
+

--- a/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/storage/FileBuildStateManager.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/storage/FileBuildStateManager.kt
@@ -91,12 +91,7 @@ class FileBuildStateManager(
     }
 
     fun updateHashes(files: Map<Path, String>) {
-        try {
-            hashStorage.batchUpdate(files)
-        } catch (e: Exception) {
-            logger.error(e) { "Не удалось обновить хеши файлов" }
-            throw e
-        }
+        hashStorage.batchUpdate(files)
     }
 
     fun storeTimestamp(

--- a/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/storage/MapDbHashStorage.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/storage/MapDbHashStorage.kt
@@ -109,9 +109,9 @@ class MapDbHashStorage(
             }
             db.commit()
         } catch (e: Exception) {
-            logger.error(e) { "Не удалось выполнить пакетное обновление хешей файлов" }
-            db.rollback()
-            throw e
+            logger.warn { "Не удалось сохранить хеши файлов (${updates.size} шт.) - кэш будет перестроен при следующей сборке" }
+            logger.debug(e) { "Детали ошибки сохранения хешей" }
+            tryRollback()
         }
     }
 
@@ -138,9 +138,20 @@ class MapDbHashStorage(
 
         logger.debug { "Временная метка сохранена для подпроекта: $sourceSetName" }
     } catch (e: Exception) {
-        logger.error(e) { "Не удалось сохранить временную метку для подпроекта: $sourceSetName" }
-        db.rollback()
-        throw e
+        logger.warn { "Не удалось сохранить временную метку для '$sourceSetName' - кэш будет перестроен при следующей сборке" }
+        logger.debug(e) { "Детали ошибки сохранения временной метки" }
+        tryRollback()
+    }
+
+    /**
+     * Безопасный rollback транзакции
+     */
+    private fun tryRollback() {
+        try {
+            db.rollback()
+        } catch (e: Exception) {
+            logger.debug { "Rollback не выполнен: ${e.message}" }
+        }
     }
 
     /**

--- a/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/utility/PartialLoadListGenerator.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/utility/PartialLoadListGenerator.kt
@@ -1,0 +1,297 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.infrastructure.utility
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.name
+import kotlin.io.path.walk
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * Генератор списка файлов для частичной загрузки конфигурации.
+ *
+ * Преобразует набор измененных файлов в список для параметра -listFile
+ * команды /LoadConfigFromFiles с учетом специфики 1С:
+ * - Для BSL файлов добавляет связанные XML объектов метаданных
+ * - Преобразует абсолютные пути в относительные от каталога конфигурации
+ */
+@Component
+class PartialLoadListGenerator {
+    /**
+     * Типы метаданных 1С и их каталоги
+     */
+    private val metadataTypes = setOf(
+        "Catalogs",
+        "Documents",
+        "DataProcessors",
+        "Reports",
+        "InformationRegisters",
+        "AccumulationRegisters",
+        "AccountingRegisters",
+        "CalculationRegisters",
+        "ChartsOfCharacteristicTypes",
+        "ChartsOfAccounts",
+        "ChartsOfCalculationTypes",
+        "ExchangePlans",
+        "BusinessProcesses",
+        "Tasks",
+        "Constants",
+        "Enums",
+        "CommonModules",
+        "CommonForms",
+        "CommonCommands",
+        "CommonTemplates",
+        "CommonPictures",
+        "SessionParameters",
+        "Roles",
+        "CommonAttributes",
+        "ExternalDataSources",
+        "FilterCriteria",
+        "EventSubscriptions",
+        "ScheduledJobs",
+        "FunctionalOptions",
+        "FunctionalOptionsParameters",
+        "DefinedTypes",
+        "SettingsStorages",
+        "Sequences",
+        "DocumentJournals",
+        "WebServices",
+        "HTTPServices",
+        "WSReferences",
+        "Styles",
+        "StyleItems",
+        "Languages",
+        "Subsystems",
+        "CommandGroups",
+        "Interfaces",
+        "XDTOPackages",
+    )
+
+    /**
+     * Генерирует файл со списком для частичной загрузки.
+     *
+     * @param sourceSetPath Базовый путь к source set (каталог конфигурации)
+     * @param changedFiles Набор абсолютных путей к измененным файлам
+     * @return Путь к временному файлу со списком
+     */
+    fun generate(
+        sourceSetPath: Path,
+        changedFiles: Set<Path>,
+    ): Path {
+        logger.debug { "Генерация списка файлов для частичной загрузки: ${changedFiles.size} файлов" }
+
+        val filesToLoad = mutableSetOf<String>()
+
+        changedFiles.forEach { absolutePath ->
+            processChangedFile(sourceSetPath, absolutePath, filesToLoad)
+        }
+
+        logger.info { "Подготовлено ${filesToLoad.size} файлов для частичной загрузки" }
+
+        return createListFile(filesToLoad)
+    }
+
+    /**
+     * Обрабатывает измененный файл и добавляет необходимые пути в список загрузки.
+     */
+    private fun processChangedFile(
+        sourceSetPath: Path,
+        absolutePath: Path,
+        filesToLoad: MutableSet<String>,
+    ) {
+        if (!absolutePath.startsWith(sourceSetPath)) {
+            logger.warn { "Файл $absolutePath не принадлежит source set $sourceSetPath" }
+            return
+        }
+
+        val relativePath = sourceSetPath.relativize(absolutePath)
+        val relativePathStr = relativePath.toString().replace("\\", "/")
+
+        when {
+            absolutePath.extension.equals("bsl", ignoreCase = true) -> {
+                processBslFile(sourceSetPath, relativePath, filesToLoad)
+            }
+            absolutePath.extension.equals("xml", ignoreCase = true) -> {
+                filesToLoad.add(relativePathStr)
+                logger.trace { "Добавлен XML: $relativePathStr" }
+            }
+            else -> {
+                filesToLoad.add(relativePathStr)
+                logger.trace { "Добавлен файл: $relativePathStr" }
+            }
+        }
+    }
+
+    /**
+     * Обрабатывает BSL файл и добавляет связанные файлы объекта метаданных.
+     *
+     * При изменении BSL модуля необходимо загрузить:
+     * 1. XML файл объекта метаданных
+     * 2. Все файлы из каталога Ext объекта (включая сам BSL)
+     */
+    private fun processBslFile(
+        sourceSetPath: Path,
+        relativePath: Path,
+        filesToLoad: MutableSet<String>,
+    ) {
+        val pathParts = relativePath.toList().map { it.toString() }
+
+        if (pathParts.isEmpty()) {
+            return
+        }
+
+        // Определяем тип метаданных и имя объекта
+        val metadataInfo = findMetadataInfo(pathParts)
+
+        if (metadataInfo != null) {
+            val (metadataType, objectName, objectIndex) = metadataInfo
+
+            // Добавляем XML объекта
+            val xmlPath = "$metadataType/$objectName.xml"
+            filesToLoad.add(xmlPath)
+            logger.trace { "Добавлен XML объекта для BSL: $xmlPath" }
+
+            // Добавляем все файлы из каталога объекта
+            val objectPath = sourceSetPath.resolve(metadataType).resolve(objectName)
+            if (objectPath.exists() && objectPath.isDirectory()) {
+                addAllFilesFromDirectory(sourceSetPath, objectPath, filesToLoad)
+            }
+        } else {
+            // Если не удалось определить объект, добавляем сам файл
+            val relativePathStr = relativePath.toString().replace("\\", "/")
+            filesToLoad.add(relativePathStr)
+            logger.trace { "Добавлен BSL без определения объекта: $relativePathStr" }
+        }
+    }
+
+    /**
+     * Информация о метаданных: (тип, имя объекта, индекс в пути)
+     */
+    private data class MetadataInfo(
+        val type: String,
+        val objectName: String,
+        val pathIndex: Int,
+    )
+
+    /**
+     * Находит информацию о метаданных по пути файла.
+     */
+    private fun findMetadataInfo(pathParts: List<String>): MetadataInfo? {
+        for (i in pathParts.indices) {
+            if (pathParts[i] in metadataTypes && i + 1 < pathParts.size) {
+                return MetadataInfo(
+                    type = pathParts[i],
+                    objectName = pathParts[i + 1],
+                    pathIndex = i,
+                )
+            }
+        }
+        return null
+    }
+
+    /**
+     * Добавляет все файлы из каталога рекурсивно.
+     */
+    private fun addAllFilesFromDirectory(
+        sourceSetPath: Path,
+        directory: Path,
+        filesToLoad: MutableSet<String>,
+    ) {
+        try {
+            directory.walk()
+                .filter { Files.isRegularFile(it) }
+                .forEach { file ->
+                    val relativePath = sourceSetPath.relativize(file).toString().replace("\\", "/")
+                    filesToLoad.add(relativePath)
+                    logger.trace { "Добавлен связанный файл: $relativePath" }
+                }
+        } catch (e: Exception) {
+            logger.warn(e) { "Ошибка при сканировании каталога: $directory" }
+        }
+    }
+
+    /**
+     * Создает временный файл со списком файлов для загрузки.
+     */
+    private fun createListFile(files: Set<String>): Path {
+        val listFile = Files.createTempFile("partial-load-", ".txt")
+
+        Files.write(listFile, files.sorted())
+
+        logger.debug { "Создан файл списка: $listFile с ${files.size} записями" }
+
+        return listFile
+    }
+
+    /**
+     * Проверяет, содержат ли изменения файл Configuration.xml.
+     * Если да, рекомендуется полная загрузка.
+     */
+    fun hasConfigurationXmlChanges(
+        sourceSetPath: Path,
+        changedFiles: Set<Path>,
+    ): Boolean {
+        return changedFiles.any { file ->
+            val relativePath = if (file.startsWith(sourceSetPath)) {
+                sourceSetPath.relativize(file)
+            } else {
+                file
+            }
+            relativePath.name.equals("Configuration.xml", ignoreCase = true)
+        }
+    }
+
+    /**
+     * Определяет, следует ли использовать частичную загрузку.
+     *
+     * @param changedFiles Набор измененных файлов
+     * @param threshold Порог количества файлов для переключения на полную загрузку
+     * @param sourceSetPath Базовый путь к source set
+     * @return true если следует использовать частичную загрузку
+     */
+    fun shouldUsePartialLoad(
+        changedFiles: Set<Path>,
+        threshold: Int,
+        sourceSetPath: Path,
+    ): Boolean {
+        if (changedFiles.size >= threshold) {
+            logger.info { "Количество изменений (${changedFiles.size}) >= порога ($threshold), используется полная загрузка" }
+            return false
+        }
+
+        if (hasConfigurationXmlChanges(sourceSetPath, changedFiles)) {
+            logger.info { "Обнаружены изменения в Configuration.xml, используется полная загрузка" }
+            return false
+        }
+
+        logger.info { "Используется частичная загрузка для ${changedFiles.size} файлов" }
+        return true
+    }
+}
+

--- a/src/main/kotlin/io/github/alkoleft/mcp/server/McpServer.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/server/McpServer.kt
@@ -21,15 +21,19 @@
 
 package io.github.alkoleft.mcp.server
 
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
 import io.github.alkoleft.mcp.application.actions.common.LaunchRequest
 import io.github.alkoleft.mcp.application.actions.test.yaxunit.RunAllTestsRequest
 import io.github.alkoleft.mcp.application.actions.test.yaxunit.RunModuleTestsRequest
 import io.github.alkoleft.mcp.application.services.DesignerConfigCheckRequest
 import io.github.alkoleft.mcp.application.services.DesignerModulesCheckRequest
+import io.github.alkoleft.mcp.application.services.DumpRequest
+import io.github.alkoleft.mcp.application.services.DumpService
 import io.github.alkoleft.mcp.application.services.EdtCheckRequest
 import io.github.alkoleft.mcp.application.services.LauncherService
 import io.github.alkoleft.mcp.application.services.SyntaxCheckService
 import io.github.alkoleft.mcp.server.dto.McpBuildResponse
+import io.github.alkoleft.mcp.server.dto.McpDumpResponse
 import io.github.alkoleft.mcp.server.dto.McpLaunchResponse
 import io.github.alkoleft.mcp.server.dto.McpSyntaxCheckResponse
 import io.github.alkoleft.mcp.server.dto.McpTestResponse
@@ -62,6 +66,7 @@ private val logger = KotlinLogging.logger { }
 class McpServer(
     private val launcherService: LauncherService,
     private val syntaxCheckService: SyntaxCheckService,
+    private val dumpService: DumpService,
 ) {
     /**
      * Запускает все тесты в проекте
@@ -182,6 +187,90 @@ class McpServer(
             return McpBuildResponse(
                 success = false,
                 message = "Ошибка при сборке: ${e.message}",
+            )
+        }
+    }
+
+    /**
+     * Выгружает конфигурацию из ИБ в файлы проекта
+     *
+     * Выполняет выгрузку конфигурации 1С:Предприятие из информационной базы
+     * в каталог проекта. Полезно для синхронизации изменений, сделанных
+     * в конфигураторе, с исходными файлами проекта.
+     *
+     * Поддерживаемые режимы выгрузки:
+     * - FULL: Полная выгрузка всей конфигурации
+     * - INCREMENTAL: Инкрементальная выгрузка только измененных объектов (требует ConfigDumpInfo.xml)
+     * - PARTIAL: Частичная выгрузка конкретных объектов по списку
+     *
+     * @param mode Режим выгрузки (FULL, INCREMENTAL, PARTIAL). По умолчанию FULL
+     * @param extension Имя расширения для выгрузки (опционально, если null - основная конфигурация)
+     * @param allExtensions Выгрузить все расширения (опционально)
+     * @param objects Список объектов метаданных для режима PARTIAL (например, "Справочник.Номенклатура")
+     * @return Результат выгрузки конфигурации
+     * @throws Exception при возникновении ошибок во время выгрузки
+     */
+    @Tool(
+        name = "dump_config",
+        description = """Выгружает конфигурацию из ИБ в файлы проекта.
+            |Режимы выгрузки:
+            |* FULL - полная выгрузка всей конфигурации
+            |* INCREMENTAL - только измененные объекты (требует предыдущую выгрузку)
+            |* PARTIAL - конкретные объекты по списку
+            |Используйте для синхронизации изменений, сделанных в конфигураторе.""",
+    )
+    fun dumpConfig(
+        @ToolParam(
+            description = "Режим выгрузки: FULL (полная), INCREMENTAL (только изменения), PARTIAL (по списку)",
+            required = false,
+        ) mode: String?,
+        @ToolParam(
+            description = "Имя расширения для выгрузки. Если не указано, выгружается основная конфигурация",
+            required = false,
+        ) extension: String?,
+        @ToolParam(
+            description = "Выгрузить все расширения",
+            required = false,
+        ) allExtensions: Boolean?,
+        @ToolParam(
+            description = "Список объектов метаданных для режима PARTIAL (например: Справочник.Номенклатура, Документ.Заказ)",
+            required = false,
+        ) objects: List<String>?,
+    ): McpDumpResponse {
+        logger.info { "Выгрузка конфигурации: режим=$mode, расширение=$extension, все расширения=$allExtensions" }
+
+        return try {
+            val dumpMode = when (mode?.uppercase()) {
+                "INCREMENTAL" -> DumpMode.INCREMENTAL
+                "PARTIAL" -> DumpMode.PARTIAL
+                else -> DumpMode.FULL
+            }
+
+            val request = DumpRequest(
+                mode = dumpMode,
+                extension = extension,
+                allExtensions = allExtensions ?: false,
+                objects = objects ?: emptyList(),
+            )
+
+            val result = dumpService.dump(request)
+
+            McpDumpResponse(
+                success = result.success,
+                message = result.message,
+                mode = result.mode.name,
+                dumpTime = result.duration.inWholeMilliseconds,
+                dumpedObjects = result.dumpedObjects,
+                errors = if (result.errors.isNotEmpty()) result.errors else null,
+                steps = if (!result.success) result.steps else null,
+            )
+        } catch (e: Exception) {
+            logger.error(e) { "Ошибка при выгрузке конфигурации" }
+            McpDumpResponse(
+                success = false,
+                message = "Ошибка при выгрузке: ${e.message}",
+                mode = mode ?: "FULL",
+                errors = listOf(e.message ?: "Неизвестная ошибка"),
             )
         }
     }

--- a/src/main/kotlin/io/github/alkoleft/mcp/server/dto/McpDumpResponse.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/server/dto/McpDumpResponse.kt
@@ -1,0 +1,48 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.server.dto
+
+import io.github.alkoleft.mcp.application.actions.common.ActionStepResult
+
+/**
+ * Результат выгрузки конфигурации в формате MCP
+ *
+ * Содержит информацию о результатах выгрузки конфигурации из ИБ в файлы, включая
+ * статус, режим выгрузки, время выполнения и детали шагов (при ошибках).
+ *
+ * @param success Успешность выгрузки (true, если выгрузка завершилась без ошибок)
+ * @param message Сообщение о результате выгрузки
+ * @param mode Режим выгрузки, который был использован (FULL, INCREMENTAL, PARTIAL)
+ * @param dumpTime Время выполнения выгрузки в миллисекундах
+ * @param dumpedObjects Количество выгруженных объектов (если известно)
+ * @param errors Список ошибок, возникших во время выгрузки
+ * @param steps Список шагов выполнения выгрузки (заполняется только при ошибках для диагностики)
+ */
+data class McpDumpResponse(
+    val success: Boolean,
+    val message: String,
+    val mode: String,
+    val dumpTime: Long? = null,
+    val dumpedObjects: Int? = null,
+    val errors: List<String>? = null,
+    val steps: List<ActionStepResult>? = null,
+)

--- a/src/test/kotlin/io/github/alkoleft/mcp/RealTests.kt
+++ b/src/test/kotlin/io/github/alkoleft/mcp/RealTests.kt
@@ -27,6 +27,7 @@ import io.github.alkoleft.mcp.application.actions.test.yaxunit.RunListTestsReque
 import io.github.alkoleft.mcp.application.actions.test.yaxunit.RunModuleTestsRequest
 import io.github.alkoleft.mcp.application.actions.test.yaxunit.YaXUnitTestAction
 import io.github.alkoleft.mcp.infrastructure.platform.dsl.PlatformDsl
+import io.github.alkoleft.mcp.infrastructure.utility.PartialLoadListGenerator
 import io.github.alkoleft.mcp.infrastructure.yaxunit.ReportParser
 import io.github.alkoleft.mcp.infrastructure.yaxunit.YaXUnitRunner
 import org.junit.jupiter.api.Test
@@ -84,7 +85,7 @@ class RealTests(
     // Тесты для DesignerBuildAction
     @Test
     fun designerBuildActionFullBuild() {
-        val action = DesignerBuildAction(platformDsl)
+        val action = DesignerBuildAction(platformDsl, PartialLoadListGenerator())
         val properties = testApplicationProperties()
 
         val result = action.run(properties, properties.sourceSet)

--- a/src/test/kotlin/io/github/alkoleft/mcp/application/actions/dump/DumpActionStateTest.kt
+++ b/src/test/kotlin/io/github/alkoleft/mcp/application/actions/dump/DumpActionStateTest.kt
@@ -1,0 +1,101 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.actions.dump
+
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
+import io.github.alkoleft.mcp.infrastructure.platform.dsl.process.ProcessResult
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+
+class DumpActionStateTest {
+    @Test
+    fun `should create successful result when dump succeeds`() {
+        // Arrange
+        val state = DumpActionState(DumpMode.FULL)
+        val processResult = ProcessResult(
+            success = true,
+            exitCode = 0,
+            output = "Выгрузка выполнена успешно",
+            error = null,
+            duration = Duration.ZERO,
+        )
+
+        // Act
+        state.registerDumpResult(processResult, "Выгрузка конфигурации", 150)
+        val result = state.toResult("Выгрузка")
+
+        // Assert
+        assertTrue(result.success)
+        assertEquals(DumpMode.FULL, result.mode)
+        assertEquals(150, result.dumpedObjects)
+        assertTrue(result.errors.isEmpty())
+        assertEquals("Выгрузка успешно", result.message)
+    }
+
+    @Test
+    fun `should create failed result when dump fails`() {
+        // Arrange
+        val state = DumpActionState(DumpMode.INCREMENTAL)
+        val processResult = ProcessResult(
+            success = false,
+            exitCode = 1,
+            output = "",
+            error = "Ошибка при выгрузке: файл занят",
+            duration = Duration.ZERO,
+        )
+
+        // Act
+        state.registerDumpResult(processResult, "Инкрементальная выгрузка")
+        val result = state.toResult("Выгрузка")
+
+        // Assert
+        assertFalse(result.success)
+        assertEquals(DumpMode.INCREMENTAL, result.mode)
+        assertTrue(result.errors.contains("Ошибка при выгрузке: файл занят"))
+        assertEquals("Выгрузка неудачно", result.message)
+    }
+
+    @Test
+    fun `should track steps correctly`() {
+        // Arrange
+        val state = DumpActionState(DumpMode.PARTIAL)
+        val processResult = ProcessResult(
+            success = true,
+            exitCode = 0,
+            output = "OK",
+            error = null,
+            duration = Duration.ZERO,
+        )
+
+        // Act
+        state.registerDumpResult(processResult, "Частичная выгрузка объектов", 5)
+        val result = state.toResult("Выгрузка")
+
+        // Assert
+        assertEquals(1, result.steps.size)
+        assertTrue(result.steps[0].message.contains("Частичная выгрузка объектов"))
+        assertTrue(result.steps[0].success)
+    }
+}

--- a/src/test/kotlin/io/github/alkoleft/mcp/application/services/DumpServiceTest.kt
+++ b/src/test/kotlin/io/github/alkoleft/mcp/application/services/DumpServiceTest.kt
@@ -1,0 +1,251 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.application.services
+
+import io.github.alkoleft.mcp.application.actions.common.DumpAction
+import io.github.alkoleft.mcp.application.actions.common.DumpMode
+import io.github.alkoleft.mcp.application.actions.common.DumpResult
+import io.github.alkoleft.mcp.configuration.properties.ApplicationProperties
+import io.github.alkoleft.mcp.configuration.properties.SourceSet
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+
+class DumpServiceTest {
+    private lateinit var dumpAction: DumpAction
+    private lateinit var properties: ApplicationProperties
+    private lateinit var sourceSetFactory: SourceSetFactory
+    private lateinit var dumpService: DumpService
+    private lateinit var mockSourceSet: SourceSet
+
+    @BeforeEach
+    fun setUp() {
+        dumpAction = mockk()
+        properties = mockk()
+        sourceSetFactory = mockk()
+        mockSourceSet = mockk()
+
+        every { sourceSetFactory.createDesignerSourceSet() } returns mockSourceSet
+
+        dumpService = DumpService(dumpAction, properties, sourceSetFactory)
+    }
+
+    @Test
+    fun `should call run for FULL mode`() {
+        // Arrange
+        val expectedResult = DumpResult(
+            message = "Выгрузка успешно",
+            success = true,
+            mode = DumpMode.FULL,
+            duration = Duration.ZERO,
+        )
+        every {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+                allExtensions = false,
+            )
+        } returns expectedResult
+
+        val request = DumpRequest(mode = DumpMode.FULL)
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertTrue(result.success)
+        assertEquals(DumpMode.FULL, result.mode)
+        verify(exactly = 1) {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+                allExtensions = false,
+            )
+        }
+    }
+
+    @Test
+    fun `should call runIncremental for INCREMENTAL mode`() {
+        // Arrange
+        val expectedResult = DumpResult(
+            message = "Инкрементальная выгрузка успешно",
+            success = true,
+            mode = DumpMode.INCREMENTAL,
+            duration = Duration.ZERO,
+        )
+        every {
+            dumpAction.runIncremental(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+            )
+        } returns expectedResult
+
+        val request = DumpRequest(mode = DumpMode.INCREMENTAL)
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertTrue(result.success)
+        assertEquals(DumpMode.INCREMENTAL, result.mode)
+        verify(exactly = 1) {
+            dumpAction.runIncremental(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+            )
+        }
+    }
+
+    @Test
+    fun `should call runPartial for PARTIAL mode with objects`() {
+        // Arrange
+        val objects = listOf("Справочник.Номенклатура", "Документ.Заказ")
+        val expectedResult = DumpResult(
+            message = "Частичная выгрузка успешно",
+            success = true,
+            mode = DumpMode.PARTIAL,
+            dumpedObjects = 2,
+            duration = Duration.ZERO,
+        )
+        every {
+            dumpAction.runPartial(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                objects = objects,
+                extension = null,
+            )
+        } returns expectedResult
+
+        val request = DumpRequest(mode = DumpMode.PARTIAL, objects = objects)
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertTrue(result.success)
+        assertEquals(DumpMode.PARTIAL, result.mode)
+        assertEquals(2, result.dumpedObjects)
+        verify(exactly = 1) {
+            dumpAction.runPartial(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                objects = objects,
+                extension = null,
+            )
+        }
+    }
+
+    @Test
+    fun `should return error for PARTIAL mode without objects`() {
+        // Arrange
+        val request = DumpRequest(mode = DumpMode.PARTIAL, objects = emptyList())
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertFalse(result.success)
+        assertEquals(DumpMode.PARTIAL, result.mode)
+        assertTrue(result.errors.any { it.contains("пуст") })
+    }
+
+    @Test
+    fun `should pass extension parameter for extension dump`() {
+        // Arrange
+        val extensionName = "МоеРасширение"
+        val expectedResult = DumpResult(
+            message = "Выгрузка расширения успешно",
+            success = true,
+            mode = DumpMode.FULL,
+            duration = Duration.ZERO,
+        )
+        every {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = extensionName,
+                allExtensions = false,
+            )
+        } returns expectedResult
+
+        val request = DumpRequest(mode = DumpMode.FULL, extension = extensionName)
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertTrue(result.success)
+        verify(exactly = 1) {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = extensionName,
+                allExtensions = false,
+            )
+        }
+    }
+
+    @Test
+    fun `should pass allExtensions flag`() {
+        // Arrange
+        val expectedResult = DumpResult(
+            message = "Выгрузка всех расширений успешно",
+            success = true,
+            mode = DumpMode.FULL,
+            duration = Duration.ZERO,
+        )
+        every {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+                allExtensions = true,
+            )
+        } returns expectedResult
+
+        val request = DumpRequest(mode = DumpMode.FULL, allExtensions = true)
+
+        // Act
+        val result = dumpService.dump(request)
+
+        // Assert
+        assertTrue(result.success)
+        verify(exactly = 1) {
+            dumpAction.run(
+                properties = properties,
+                sourceSet = mockSourceSet,
+                extension = null,
+                allExtensions = true,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/io/github/alkoleft/mcp/infrastructure/utility/PartialLoadListGeneratorTest.kt
+++ b/src/test/kotlin/io/github/alkoleft/mcp/infrastructure/utility/PartialLoadListGeneratorTest.kt
@@ -1,0 +1,286 @@
+/*
+ * This file is part of METR.
+ *
+ * Copyright (C) 2025 Aleksey Koryakin <alkoleft@gmail.com> and contributors.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * METR is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * METR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with METR.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.alkoleft.mcp.infrastructure.utility
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PartialLoadListGeneratorTest {
+    private lateinit var generator: PartialLoadListGenerator
+
+    @BeforeEach
+    fun setUp() {
+        generator = PartialLoadListGenerator()
+    }
+
+    @Test
+    fun `should generate list file with XML files`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        Files.createDirectories(sourceSetPath.resolve("Catalogs"))
+        val xmlFile = sourceSetPath.resolve("Catalogs/Catalog1.xml")
+        Files.writeString(xmlFile, "<catalog/>")
+
+        val changedFiles = setOf(xmlFile)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        assertTrue(Files.exists(listFile))
+        val content = Files.readAllLines(listFile)
+        assertEquals(1, content.size)
+        assertEquals("Catalogs/Catalog1.xml", content[0])
+    }
+
+    @Test
+    fun `should add XML object when BSL file changed`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        val catalogDir = sourceSetPath.resolve("Catalogs/Справочник1")
+        val extDir = catalogDir.resolve("Ext")
+        Files.createDirectories(extDir)
+
+        // Создаем файлы
+        Files.writeString(sourceSetPath.resolve("Catalogs/Справочник1.xml"), "<catalog/>")
+        val bslFile = extDir.resolve("ObjectModule.bsl")
+        Files.writeString(bslFile, "// Module code")
+
+        val changedFiles = setOf(bslFile)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        assertTrue(Files.exists(listFile))
+        val content = Files.readAllLines(listFile)
+
+        // Должен содержать XML объекта и BSL модуль
+        assertTrue(content.any { it == "Catalogs/Справочник1.xml" })
+        assertTrue(content.any { it == "Catalogs/Справочник1/Ext/ObjectModule.bsl" })
+    }
+
+    @Test
+    fun `should add all related files from object directory when BSL changed`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        val documentDir = sourceSetPath.resolve("Documents/Документ1")
+        val extDir = documentDir.resolve("Ext")
+        val formsDir = documentDir.resolve("Forms/ФормаДокумента")
+        Files.createDirectories(extDir)
+        Files.createDirectories(formsDir.resolve("Ext"))
+
+        // Создаем файлы объекта
+        Files.writeString(sourceSetPath.resolve("Documents/Документ1.xml"), "<document/>")
+        Files.writeString(extDir.resolve("ObjectModule.bsl"), "// Object module")
+        Files.writeString(extDir.resolve("ManagerModule.bsl"), "// Manager module")
+        Files.writeString(formsDir.resolve("Ext/Form.xml"), "<form/>")
+        Files.writeString(formsDir.resolve("Ext/Form.bsl"), "// Form module")
+
+        // Изменили только ObjectModule.bsl
+        val changedFiles = setOf(extDir.resolve("ObjectModule.bsl"))
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        val content = Files.readAllLines(listFile)
+
+        // Должен содержать все файлы объекта
+        assertTrue(content.any { it == "Documents/Документ1.xml" })
+        assertTrue(content.any { it.contains("ObjectModule.bsl") })
+        assertTrue(content.any { it.contains("ManagerModule.bsl") })
+        assertTrue(content.any { it.contains("Form.xml") })
+        assertTrue(content.any { it.contains("Form.bsl") })
+    }
+
+    @Test
+    fun `should detect Configuration xml changes`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        Files.createDirectories(sourceSetPath)
+        val configXml = sourceSetPath.resolve("Configuration.xml")
+        Files.writeString(configXml, "<configuration/>")
+
+        val changedFilesWithConfig = setOf(configXml)
+        val changedFilesWithoutConfig = setOf(sourceSetPath.resolve("Catalogs/Catalog1.xml"))
+
+        // Act & Assert
+        assertTrue(generator.hasConfigurationXmlChanges(sourceSetPath, changedFilesWithConfig))
+        assertFalse(generator.hasConfigurationXmlChanges(sourceSetPath, changedFilesWithoutConfig))
+    }
+
+    @Test
+    fun `should use partial load when under threshold and no Configuration xml changes`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        Files.createDirectories(sourceSetPath.resolve("Catalogs"))
+        val changedFiles = (1..10).map {
+            val file = sourceSetPath.resolve("Catalogs/Catalog$it.xml")
+            Files.writeString(file, "<catalog/>")
+            file
+        }.toSet()
+
+        // Act & Assert
+        assertTrue(generator.shouldUsePartialLoad(changedFiles, 20, sourceSetPath))
+        assertFalse(generator.shouldUsePartialLoad(changedFiles, 5, sourceSetPath))
+    }
+
+    @Test
+    fun `should not use partial load when Configuration xml is changed`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        Files.createDirectories(sourceSetPath)
+        val configXml = sourceSetPath.resolve("Configuration.xml")
+        Files.writeString(configXml, "<configuration/>")
+
+        val changedFiles = setOf(configXml)
+
+        // Act & Assert
+        assertFalse(generator.shouldUsePartialLoad(changedFiles, 100, sourceSetPath))
+    }
+
+    @Test
+    fun `should handle CommonModules BSL files`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        val moduleDir = sourceSetPath.resolve("CommonModules/ОбщийМодуль1")
+        val extDir = moduleDir.resolve("Ext")
+        Files.createDirectories(extDir)
+
+        Files.writeString(sourceSetPath.resolve("CommonModules/ОбщийМодуль1.xml"), "<commonModule/>")
+        val bslFile = extDir.resolve("Module.bsl")
+        Files.writeString(bslFile, "// Common module code")
+
+        val changedFiles = setOf(bslFile)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        val content = Files.readAllLines(listFile)
+        assertTrue(content.any { it == "CommonModules/ОбщийМодуль1.xml" })
+        assertTrue(content.any { it.contains("Module.bsl") })
+    }
+
+    @Test
+    fun `should handle DataProcessors BSL files`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        val processorDir = sourceSetPath.resolve("DataProcessors/Обработка1")
+        val extDir = processorDir.resolve("Ext")
+        Files.createDirectories(extDir)
+
+        Files.writeString(sourceSetPath.resolve("DataProcessors/Обработка1.xml"), "<dataProcessor/>")
+        val bslFile = extDir.resolve("ObjectModule.bsl")
+        Files.writeString(bslFile, "// Data processor module")
+
+        val changedFiles = setOf(bslFile)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        val content = Files.readAllLines(listFile)
+        assertTrue(content.any { it == "DataProcessors/Обработка1.xml" })
+        assertTrue(content.any { it.contains("ObjectModule.bsl") })
+    }
+
+    @Test
+    fun `should handle multiple changed files from different objects`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+
+        // Catalog
+        val catalogDir = sourceSetPath.resolve("Catalogs/Справочник1/Ext")
+        Files.createDirectories(catalogDir)
+        Files.writeString(sourceSetPath.resolve("Catalogs/Справочник1.xml"), "<catalog/>")
+        val catalogBsl = catalogDir.resolve("ObjectModule.bsl")
+        Files.writeString(catalogBsl, "// Catalog module")
+
+        // Document
+        val documentDir = sourceSetPath.resolve("Documents/Документ1/Ext")
+        Files.createDirectories(documentDir)
+        Files.writeString(sourceSetPath.resolve("Documents/Документ1.xml"), "<document/>")
+        val documentBsl = documentDir.resolve("ObjectModule.bsl")
+        Files.writeString(documentBsl, "// Document module")
+
+        val changedFiles = setOf(catalogBsl, documentBsl)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        val content = Files.readAllLines(listFile)
+        assertTrue(content.any { it == "Catalogs/Справочник1.xml" })
+        assertTrue(content.any { it == "Documents/Документ1.xml" })
+        assertTrue(content.any { it.contains("Catalogs/Справочник1/Ext/ObjectModule.bsl") })
+        assertTrue(content.any { it.contains("Documents/Документ1/Ext/ObjectModule.bsl") })
+    }
+
+    @Test
+    fun `should skip files outside source set path`(
+        @TempDir tempDir: Path,
+    ) {
+        // Arrange
+        val sourceSetPath = tempDir.resolve("config")
+        Files.createDirectories(sourceSetPath)
+
+        val outsideFile = tempDir.resolve("other/file.xml")
+        Files.createDirectories(outsideFile.parent)
+        Files.writeString(outsideFile, "<data/>")
+
+        val changedFiles = setOf(outsideFile)
+
+        // Act
+        val listFile = generator.generate(sourceSetPath, changedFiles)
+
+        // Assert
+        val content = Files.readAllLines(listFile)
+        assertTrue(content.isEmpty())
+    }
+}
+


### PR DESCRIPTION
## Описание
Добавлена поддержка частичной загрузки конфигурации для ускорения сборки.
Вместо загрузки всех файлов загружаются только измененные через параметры `-partial -listFile`.

Вдохновлено проектом: https://github.com/Nikolay-Shirokov/partial-load-config

## Изменения
- `PartialLoadListGenerator` — генерация списка файлов с BSL→XML маппингом
- Расширен `BuildAction` методом `runPartial()`
- Реализация для DESIGNER (`-partial -listFile`) и IBCMD (`config import files --partial`)
- Настраиваемый порог: `app.build.partial-load-threshold` (по умолчанию 20)
- Улучшена обработка ошибок MapDB

## Результат
Сборка 2 файлов: **~60 сек** вместо **~15 мин** 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена поддержка экспорта конфигурации (dump) с режимами FULL/INCREMENTAL/PARTIAL и новый серверный endpoint для запуска экспорта.
  * Добавлена поддержка частичной загрузки при построении для повышения производительности при небольших изменениях.

* **Конфигурация**
  * Новый параметр конфигурации build.partialLoadThreshold (по умолчанию 20).
  * .gitignore обновлён разделом «Локальная конфигурация».

* **Тесты**
  * Добавлено широкое покрытие тестами для частичной загрузки и экспортных сценариев.

* **Улучшения**
  * Обновлена обработка ошибок и устойчивость работы со стореджем.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->