### PR TITLE
fix: remove incorrect 1cedt subdirectory from EdtWindowsSearchStrategy

### DIFF
--- a/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/platform/dsl/edt/EdtCliExecutor.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/platform/dsl/edt/EdtCliExecutor.kt
@@ -79,10 +79,17 @@ class EdtCliExecutor(
                 exitCode = result.exitCode,
             )
         } else {
+            val hasErrors =
+                output.lines().any { line ->
+                    val trimmed = line.trim()
+                    trimmed.startsWith("ERROR", ignoreCase = true) ||
+                        trimmed.startsWith("CRITICAL", ignoreCase = true) ||
+                        trimmed.startsWith("FATAL", ignoreCase = true)
+                }
             return EdtCommandResult(
-                success = output.isBlank(),
+                success = !hasErrors,
                 output = output,
-                error = output,
+                error = if (hasErrors) output else null,
                 duration = result.duration,
                 exitCode = result.exitCode,
             )

--- a/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/platform/search/SearchStrategy.kt
+++ b/src/main/kotlin/io/github/alkoleft/mcp/infrastructure/platform/search/SearchStrategy.kt
@@ -165,10 +165,9 @@ object EdtWindowsSearchStrategy : SearchStrategy {
     fun systemLocations() =
         System.getenv("PROGRAMFILES")?.let {
             listOf(
-                // Components: 1c-edt-<ver>-<arch>/1cedt/
+                // Components: 1c-edt-<ver>-<arch>/1cedtcli.exe (Windows has executables in component root)
                 DirectoryEnumeratingLocation(
                     basePath = Paths.get(it, "1C", "1CE", "components").toString(),
-                    relativeExecutableSubPath = "1cedt",
                 ) { dir ->
                     dir.substringAfter("1c-edt-")
                 },
@@ -178,10 +177,9 @@ object EdtWindowsSearchStrategy : SearchStrategy {
     fun userLocation() =
         System.getenv("LOCALAPPDATA")?.let {
             listOf(
-                // 1C_EDT <ver>/1cedt/
+                // 1C_EDT <ver>/ — Windows has executables in installation root
                 DirectoryEnumeratingLocation(
                     basePath = Paths.get(it, "1C", "1cedtstart", "installations").toString(),
-                    relativeExecutableSubPath = "1cedt",
                 ) { dir ->
                     dir.substringAfter("1C_EDT ", "")
                 },


### PR DESCRIPTION
On Windows, EDT CLI executables (1cedtcli.exe) are located in the component/installation root directory, not in a "1cedt" subdirectory. The relativeExecutableSubPath = "1cedt" caused the search to look at a non-existent path, resulting in "EDT_CLI не найден ни в одной известной локации" error on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Исправлена логика определения расположения исполняемых файлов для установок EDT на Windows — теперь файлы корректно обнаруживаются в корневых директориях как для компонентных, так и для пользовательских установок.
  * Улучшена обработка результатов вызовов EDT: вывод теперь проверяется на строки с уровнями ошибок (ERROR/CRITICAL/FATAL) и считается неуспешным только при их наличии; текст ошибки возвращается лишь при обнаружении таких маркеров.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->